### PR TITLE
Move cmd args to entry key

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,6 @@
 - id: prettier
   name: prettier
-  entry: prettier
-  args:
-    - "--write"
-    - "--list-different"
-    - "--ignore-unknown"
+  entry: prettier --write --list-different --ignore-unknown
   language: node
   additional_dependencies:
     - prettier@2.1.2


### PR DESCRIPTION
As in https://github.com/prettier/prettier/blob/master/.pre-commit-hooks.yaml#L3

This frees args keyword, so that it can be used downstream in pre-commit
hooks

Fixes https://github.com/prettier/pre-commit/issues/16