### PR TITLE
Move prettier from devDependencies to dependencies

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,5 +6,3 @@
     - "--list-different"
     - "--ignore-unknown"
   language: node
-  additional_dependencies:
-    - prettier@2.1.2

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "private": true,
   "devDependencies": {
     "execa": "4.0.3",
-    "listr": "0.14.3",
-    "prettier": "2.1.2"
+    "listr": "0.14.3"
   },
   "scripts": {
     "release": "node ./scripts/release-version.js",
@@ -17,6 +16,7 @@
     "format": "prettier . --write"
   },
   "dependencies": {
-    "enquirer": "2.3.6"
+    "enquirer": "2.3.6",
+    "prettier": "2.1.2"
   }
 }


### PR DESCRIPTION
This frees additional_dependencies keyword, so that it can be used downstream in pre-commit
hooks

Fixes #16